### PR TITLE
Arch varnish

### DIFF
--- a/arch/PKGBUILD
+++ b/arch/PKGBUILD
@@ -14,12 +14,7 @@ license=('BSD')
 
 build() {
     cd $name
-    if [ -e ./bootstrap -a -x ./bootstrap ]; then
-        ./bootstrap
-    else
-        ./autogen.sh
-    fi
-    ./configure \
+    $startdir/__vmod-package_config.sh \
         --build="$CBUILD" \
         --host="$CHOST" \
         --prefix=/usr \

--- a/arch/pkg.sh
+++ b/arch/pkg.sh
@@ -10,5 +10,5 @@ sed ${SCRIPT_DIR}/PKGBUILD \
     -e "s/%VMOD%/${VMP_VMOD_NAME}/g" \
     -e "s/%VER%/${VMP_VMOD_VER}/g" \
     -e "s/%VARNISH_VER%/${VMP_VARNISH_VER}/g" \
-    -e "s/%REQUIRE%/${VMP_REQUIRE_RPM}/g" \
+    -e "s/%REQUIRE%/${VMP_REQUIRE_ARCH}/g" \
     > ${VMP_WORK_DIR}/PKGBUILD

--- a/docker/init/arch
+++ b/docker/init/arch
@@ -1,6 +1,7 @@
 FROM archlinux:base-devel
 
 RUN \
-	pacman -Suvvy --noconfirm gcc libnsl pcre2 python-docutils python-sphinx git && \
+	pacman -Suvvy --noconfirm autoconf-archive gcc libnsl pcre2 python-docutils python-sphinx git && \
 	useradd builder && \
-	echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
+	echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers && \
+	echo 'MAKEFLAGS="-j$(nproc)"' >> /etc/makepkg.conf

--- a/sample-src/libvdp-pesi_config.sh
+++ b/sample-src/libvdp-pesi_config.sh
@@ -3,4 +3,4 @@
 #https://gitlab.com/uplex/varnish/libvdp-pesi
 
 ./autogen.sh
-./configure VARNISHSRC=/tmp/varnish/src
+./configure VARNISHSRC=/tmp/varnish/src $@

--- a/sample-src/libvdp-pesi_init.sh
+++ b/sample-src/libvdp-pesi_init.sh
@@ -2,4 +2,6 @@
 
 #https://gitlab.com/uplex/varnish/libvdp-pesi
 
-cp -rp ${VMP_ROOT_DIR}/src/m4 ${VMP_WORK_DIR}/src/m4
+if [ ${VMP_PKGTYPE} != "arch" ]; then
+    cp -rp ${VMP_ROOT_DIR}/src/m4 ${VMP_WORK_DIR}/src/m4
+fi

--- a/script/arch/arch-postfilter.sh
+++ b/script/arch/arch-postfilter.sh
@@ -15,4 +15,4 @@ chown builder -R .
 su builder -c "makepkg --force --noconfirm --nodeps --skipinteg $TMP_TEST"
 
 mkdir -p ${VMP_ROOT_DIR}/pkgs/arch/${VMP_VMOD_NAME}
-find ${VMP_WORK_DIR} -type f -name *.tar.zst | xargs -i cp -p {} ${VMP_ROOT_DIR}/pkgs/arch/${VMP_VMOD_NAME}/
+cp *.tar.zst ${VMP_ROOT_DIR}/pkgs/arch/${VMP_VMOD_NAME}/

--- a/script/arch/arch-postfilter.sh
+++ b/script/arch/arch-postfilter.sh
@@ -10,10 +10,9 @@ else
 fi
 
 cd ${VMP_WORK_DIR}
-set -x
+
 chown builder -R .
-su builder -c "makepkg --force --geninteg" >> PKGBUILD
-su builder -c "makepkg --force --noconfirm --nodeps ${TMP_TEST}"
+su builder -c "makepkg --force --noconfirm --nodeps --skipinteg $TMP_TEST"
 
 mkdir -p ${VMP_ROOT_DIR}/pkgs/arch/${VMP_VMOD_NAME}
 find ${VMP_WORK_DIR} -type f -name *.tar.zst | xargs -i cp -p {} ${VMP_ROOT_DIR}/pkgs/arch/${VMP_VMOD_NAME}/

--- a/script/arch/arch-varnish-build.sh
+++ b/script/arch/arch-varnish-build.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
 rm -rf ${VMP_ROOT_DIR}/pkg
 cp -rpL ${VMP_VARNISH_ORG_DIR}/pkg-varnish-cache/arch ${VMP_ROOT_DIR}/pkg/
+cp ${VMP_ROOT_DIR}/src/varnish-*.tar.gz ${VMP_ROOT_DIR}/pkg/src.tgz
 
 RELEASE=-1
 
@@ -18,12 +19,15 @@ else
     VERSION=${VMP_VARNISH_VER}
 fi
 
-sed -i -e "s|@VERSION@|${VERSION}|"  "${VMP_ROOT_DIR}/pkg/PKGBUILD"
-
+sed -i \
+    -e "s|@VERSION@|${VERSION}|" \
+    -e 's|cd "varnish-$pkgver"|cd varnish-*|' \
+    -e 's|^source=.*|source=(src.tgz|' \
+    "${VMP_ROOT_DIR}/pkg/PKGBUILD"
 cd ${VMP_ROOT_DIR}/pkg
 
 su builder -c "makepkg -rsf --noconfirm --skipinteg"
 
 mkdir -p ${VMP_ROOT_DIR}/pkgs/arch/varnish
 
-cp ${VMP_ROOT_DIR}/pkg/varnish*${VERSION}*.zst ${VMP_ROOT_DIR}/pkgs/arch/varnish/
+cp ${VMP_ROOT_DIR}/pkg/varnish*.zst ${VMP_ROOT_DIR}/pkgs/arch/varnish/

--- a/script/arch/arch-varnish-build.sh
+++ b/script/arch/arch-varnish-build.sh
@@ -5,10 +5,10 @@ echo "VMP>>>$0 : varnish"
 
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
-(
-	cd ${VMP_ROOT_DIR}/src/
-	tar cfz ${VMP_WORK_DIR}/src.tgz *
-)
+rm -rf ${VMP_ROOT_DIR}/pkg
+cp -rpL ${VMP_VARNISH_ORG_DIR}/pkg-varnish-cache/arch ${VMP_ROOT_DIR}/pkg/
+
+RELEASE=-1
 
 if [ -n "${VMP_VARNISH_SRC}" ]; then
     VERSION=$(date +%Y%m%d).${VMP_HASH:0:7}
@@ -18,15 +18,12 @@ else
     VERSION=${VMP_VARNISH_VER}
 fi
 
-# TODO cp all other files
-sed ${SCRIPT_DIR}/PKGBUILD \
-    -r "s/%VERSION%/$VERSION/" \
-    ${VMP_WORK_DIR}/PKGBUILD
+sed -i -e "s|@VERSION@|${VERSION}|"  "${VMP_ROOT_DIR}/pkg/PKGBUILD"
 
-(
-    cd ${VMP_WORK_DIR}/
-    makepkg -g -f -p PKGBUILD
-)
+cd ${VMP_ROOT_DIR}/pkg
+
+su builder -c "makepkg -rsf --noconfirm --skipinteg"
 
 mkdir -p ${VMP_ROOT_DIR}/pkgs/arch/varnish
-find ${VMP_WORK_DIR} -type f -name varnish-${VERSION}*.zst  -exec cp -p {} ${VMP_ROOT_DIR}/pkgs/arch/varnish/ \;
+
+cp ${VMP_ROOT_DIR}/pkg/varnish*${VERSION}*.zst ${VMP_ROOT_DIR}/pkgs/arch/varnish/

--- a/script/default/default_config.sh
+++ b/script/default/default_config.sh
@@ -4,4 +4,4 @@ if [ -e ./autogen.sh ]; then
 else
     ./bootstrap
 fi
-./configure
+./configure $@

--- a/script/test/digest.patch
+++ b/script/test/digest.patch
@@ -1,0 +1,11 @@
+--- src/tests/test02.vtc.old	2022-01-15 19:16:12.259872621 -0800
++++ src/tests/test02.vtc	2022-01-15 19:16:16.096539208 -0800
+@@ -2,7 +2,7 @@
+ 
+ server s1 { } -start
+ 
+-varnish v1 -arg "-p workspace_client=9k" -vcl+backend {
++varnish v1 -vcl+backend {
+ 	import digest from "${vmod_topbuild}/src/.libs/libvmod_digest.so";
+ 	import vtc;
+ 

--- a/script/test/pesi.patch
+++ b/script/test/pesi.patch
@@ -1,0 +1,29 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -32,7 +32,7 @@ AC_ARG_WITH([rst2man],
+ 		[--with-rst2man=PATH],
+ 		[Location of rst2man (auto)]),
+ 	[RST2MAN="$withval"],
+-	AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], []))
++	[AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py])])
+ AM_CONDITIONAL(HAVE_RST2MAN, [test "x$RST2MAN" != "xno"])
+ 
+ AC_ARG_WITH([lcov],
+@@ -40,7 +40,7 @@ AC_ARG_WITH([lcov],
+ 		[--with-lcov=PATH],
+ 		[Location of lcov to generate coverage data (auto)]),
+ 	[LCOV="$withval"],
+-	AC_CHECK_PROGS(LCOV, [lcov], []))
++	[AC_CHECK_PROGS(LCOV, [lcov])])
+ AM_CONDITIONAL(HAVE_LCOV, [test -n "$LCOV"])
+ 
+ AC_ARG_WITH([genhtml],
+@@ -48,7 +48,7 @@ AC_ARG_WITH([genhtml],
+ 		[--with-genhtml=PATH],
+ 		[Location of genhtml to generate coverage reports (auto)]),
+ 	[GENHTML="$withval"],
+-	AC_CHECK_PROGS(GENHTML, [genhtml], []))
++	[AC_CHECK_PROGS(GENHTML, [genhtml])])
+ AM_CONDITIONAL(HAVE_GENHTML, [test -n "$GENHTML"])
+ 
+ m4_ifndef([VARNISH_PREREQ], AC_MSG_ERROR([Need varnish.m4 -- see README.rst]))

--- a/script/test/test.sh
+++ b/script/test/test.sh
@@ -83,8 +83,8 @@ export VMP_DBG_CACHE=1
 ./vmod-packager.sh -t -d arch -k -v 7.0.0 src/test-libvdp-pesi70; ls ${VRD}/pkgs/arch/test-libvdp-pesi70/test-libvdp-pesi70-140.0.1-1-x86_64.pkg.tar.zst; ls ${VRD}/pkgs/arch/varnish/varnish-7.0.0-1-x86_64.pkg.tar.zst
 
 # varnish-modules
-./vmod-packager.sh -t -d focal -k -r varnish-cache src/test-varnish-modules70; ls ${VRD}/pkgs/debs/test-libvdp-pesi70/test-libvdp-pesi70_140.0.1~focal-1_amd64.deb; ls ${VRD}/pkgs/debs/varnish/varnish_`date +%Y%m%d`.*-1vmp+fromsrc~focal_amd64.deb
-./vmod-packager.sh -t -d centos8 -k -r varnish-cache src/test-varnish-modules70; ls ${VRD}/pkgs/rpms/test-libvdp-pesi70/test-libvdp-pesi70-140.0.1-1.el8.x86_64.rpm; ls ${VRD}/pkgs/rpms/varnish/varnish-`date +%Y%m%d`.*-1vmp+fromsrc.el8.x86_64.rpm
-./vmod-packager.sh -t -d arch -k -r varnish-cache src/test-varnish-modules70/; ls pkgs/arch/varnish/varnish-`date +%Y%m%d`.*-1-x86_64.pkg.tar.zst
+./vmod-packager.sh -t -d focal -k -r varnish-cache src/test-varnish-modules70; ls ${VRD}/pkgs/debs/test-libvdp-pesi70/test-libvdp-pesi70_140.0.1~focal-1_amd64.deb; ls ${VRD}/pkgs/debs/varnish/varnish_`date -u +%Y%m%d`*.*-1vmp+fromsrc~focal_amd64.deb
+./vmod-packager.sh -t -d centos8 -k -r varnish-cache src/test-varnish-modules70; ls ${VRD}/pkgs/rpms/test-libvdp-pesi70/test-libvdp-pesi70-140.0.1-1.el8.x86_64.rpm; ls ${VRD}/pkgs/rpms/varnish/varnish-`date -u +%Y%m%d`*.*-1vmp+fromsrc.el8.x86_64.rpm
+./vmod-packager.sh -t -d arch -k -r varnish-cache src/test-varnish-modules70/; ls pkgs/arch/varnish/varnish-`date -u +%Y%m%d`*.*-1-x86_64.pkg.tar.zst
 
 echo "pass basic test"

--- a/script/test/test.sh
+++ b/script/test/test.sh
@@ -24,6 +24,17 @@ curl -sL https://github.com/varnish/varnish-modules/archive/refs/heads/7.0.tar.g
 curl -sL https://github.com/varnish/libvmod-digest/archive/1793bea9e9b7c7dce4d8df82397d22ab9fa296f0.tar.gz | tar zx -C test-libvmod-digest70 --strip-components 1
 curl -sL https://gitlab.com/uplex/varnish/libvdp-pesi/-/archive/7.0/libvdp-pesi-7.0.tar.gz | tar zx -C test-libvdp-pesi70 --strip-components 1
 
+# need patch pesi
+(
+    cd test-libvdp-pesi70
+    patch < ../../script/test/pesi.patch
+)
+# and digest (https://github.com/varnish/libvmod-digest/pull/45)
+(
+    cd test-libvmod-digest70
+    patch -p0 < ../../script/test/digest.patch
+)
+
 # copy custom script
 cp ${VRD}/sample-src/libvmod-digest_init.sh ${VRD}/src/test-libvmod-digest70_init.sh
 cp ${VRD}/sample-src/libvmod-digest_env.sh  ${VRD}/src/test-libvmod-digest70_env.sh
@@ -69,6 +80,7 @@ export VMP_DBG_CACHE=1
 ./vmod-packager.sh -t -d focal -k -v 7.0.0 src/test-libvdp-pesi70; ls ${VRD}/pkgs/debs/test-libvdp-pesi70/test-libvdp-pesi70_140.0.1~focal-1_amd64.deb; ls ${VRD}/pkgs/debs/varnish/varnish_7.0.0-1vmp~focal_amd64.deb
 ./vmod-packager.sh -t -d buster -k -v 7.0.0 src/test-libvdp-pesi70; ls ${VRD}/pkgs/debs/test-libvdp-pesi70/test-libvdp-pesi70_140.0.1~buster-1_amd64.deb; ls ${VRD}/pkgs/debs/varnish/varnish_7.0.0-1vmp~buster_amd64.deb
 ./vmod-packager.sh -t -d centos8 -k -v 7.0.0 src/test-libvdp-pesi70; ls ${VRD}/pkgs/rpms/test-libvdp-pesi70/test-libvdp-pesi70-140.0.1-1.el8.x86_64.rpm; ls ${VRD}/pkgs/rpms/varnish/varnish-7.0.0-1vmp.el8.x86_64.rpm
+./vmod-packager.sh -t -d arch -k -v 7.0.0 src/test-libvdp-pesi70; ls ${VRD}/pkgs/arch/test-libvdp-pesi70/test-libvdp-pesi70-140.0.1-1-x86_64.pkg.tar.zst; ls ${VRD}/pkgs/arch/varnish/varnish-7.0.0-1-x86_64.pkg.tar.zst
 
 # varnish-modules
 ./vmod-packager.sh -t -d focal -k -r varnish-cache src/test-varnish-modules70; ls ${VRD}/pkgs/debs/test-libvdp-pesi70/test-libvdp-pesi70_140.0.1~focal-1_amd64.deb; ls ${VRD}/pkgs/debs/varnish/varnish_`date +%Y%m%d`.*-1vmp+fromsrc~focal_amd64.deb

--- a/script/test/test.sh
+++ b/script/test/test.sh
@@ -15,6 +15,8 @@ mkdir -p src/test-varnish-modules60
 mkdir -p src/test-varnish-modules70
 mkdir -p src/test-libvmod-digest70
 mkdir -p src/test-libvdp-pesi70
+mkdir -p varnish/varnish-cache
+curl -sL https://varnish-cache.org/_downloads/varnish-7.0.1.tgz | tar zx -C varnish/varnish-cache --strip-components 1
 
 cd ${VRD}/src
 curl -sL https://github.com/varnish/varnish-modules/archive/refs/heads/6.0-lts.tar.gz   | tar zx -C test-varnish-modules60 --strip-components 1
@@ -33,44 +35,44 @@ cd ${VRD}
 export VMP_DBG_CACHE=1
 
 #ubuntu
-./vmod-packager.sh -t -d focal -v 6.0.8 test-varnish-modules60 && ls ${VRD}/pkgs/debs/test-varnish-modules60/test-varnish-modules60_71.0.1~focal-1_amd64.deb
-./vmod-packager.sh -t -d focal -v 7.0.0 test-varnish-modules70 && ls ${VRD}/pkgs/debs/test-varnish-modules70/test-varnish-modules70_140.0.1~focal-1_amd64.deb
+./vmod-packager.sh -t -d focal -v 6.0.8 test-varnish-modules60; ls ${VRD}/pkgs/debs/test-varnish-modules60/test-varnish-modules60_71.0.1~focal-1_amd64.deb
+./vmod-packager.sh -t -d focal -v 7.0.0 test-varnish-modules70; ls ${VRD}/pkgs/debs/test-varnish-modules70/test-varnish-modules70_140.0.1~focal-1_amd64.deb
 
-./vmod-packager.sh -t -d bionic -v 6.0.8 test-varnish-modules60 && ls ${VRD}/pkgs/debs/test-varnish-modules60/test-varnish-modules60_71.0.1~bionic-1_amd64.deb
-./vmod-packager.sh -t -d bionic -v 7.0.0 test-varnish-modules70 && ls ${VRD}/pkgs/debs/test-varnish-modules70/test-varnish-modules70_140.0.1~bionic-1_amd64.deb
+./vmod-packager.sh -t -d bionic -v 6.0.8 test-varnish-modules60; ls ${VRD}/pkgs/debs/test-varnish-modules60/test-varnish-modules60_71.0.1~bionic-1_amd64.deb
+./vmod-packager.sh -t -d bionic -v 7.0.0 test-varnish-modules70; ls ${VRD}/pkgs/debs/test-varnish-modules70/test-varnish-modules70_140.0.1~bionic-1_amd64.deb
 
 #debian
-./vmod-packager.sh -t -d buster -v 6.0.8 test-varnish-modules60 && ls ${VRD}/pkgs/debs/test-varnish-modules60/test-varnish-modules60_71.0.1~buster-1_amd64.deb
-./vmod-packager.sh -t -d buster -v 7.0.0 test-varnish-modules70 && ls ${VRD}/pkgs/debs/test-varnish-modules70/test-varnish-modules70_140.0.1~buster-1_amd64.deb
+./vmod-packager.sh -t -d buster -v 6.0.8 test-varnish-modules60; ls ${VRD}/pkgs/debs/test-varnish-modules60/test-varnish-modules60_71.0.1~buster-1_amd64.deb
+./vmod-packager.sh -t -d buster -v 7.0.0 test-varnish-modules70; ls ${VRD}/pkgs/debs/test-varnish-modules70/test-varnish-modules70_140.0.1~buster-1_amd64.deb
 
-./vmod-packager.sh -t -d bullseye -v 6.0.8 test-varnish-modules60 && ls ${VRD}/pkgs/debs/test-varnish-modules60/test-varnish-modules60_71.0.1~bullseye-1_amd64.deb
-./vmod-packager.sh -t -d bullseye -v 7.0.0 test-varnish-modules70 && ls ${VRD}/pkgs/debs/test-varnish-modules70/test-varnish-modules70_140.0.1~bullseye-1_amd64.deb
+./vmod-packager.sh -t -d bullseye -v 6.0.8 test-varnish-modules60; ls ${VRD}/pkgs/debs/test-varnish-modules60/test-varnish-modules60_71.0.1~bullseye-1_amd64.deb
+./vmod-packager.sh -t -d bullseye -v 7.0.0 test-varnish-modules70; ls ${VRD}/pkgs/debs/test-varnish-modules70/test-varnish-modules70_140.0.1~bullseye-1_amd64.deb
 
 #centos
-./vmod-packager.sh -t -d centos8 -v 6.0.8 test-varnish-modules60 && ls ${VRD}/pkgs/rpms/test-varnish-modules60/test-varnish-modules60-71.0.1-1.el8.x86_64.rpm
-./vmod-packager.sh -t -d centos8 -v 7.0.0 test-varnish-modules70 && ls ${VRD}/pkgs/rpms/test-varnish-modules70/test-varnish-modules70-140.0.1-1.el8.x86_64.rpm
+./vmod-packager.sh -t -d centos8 -v 6.0.8 test-varnish-modules60; ls ${VRD}/pkgs/rpms/test-varnish-modules60/test-varnish-modules60-71.0.1-1.el8.x86_64.rpm
+./vmod-packager.sh -t -d centos8 -v 7.0.0 test-varnish-modules70; ls ${VRD}/pkgs/rpms/test-varnish-modules70/test-varnish-modules70-140.0.1-1.el8.x86_64.rpm
 
 # arch
-./vmod-packager.sh -t -d arch -v 7.0.0 test-varnish-modules70 && ls ${VRD}/pkgs/arch/test-varnish-modules70/test-varnish-modules70-140.0.1-1-x86_64.pkg.tar.zst
+./vmod-packager.sh -t -d arch -v 7.0.0 test-varnish-modules70; ls ${VRD}/pkgs/arch/test-varnish-modules70/test-varnish-modules70-140.0.1-1-x86_64.pkg.tar.zst
 
 #https://github.com/varnishcache/varnish-cache/commit/454733b82a3279a1603516b4f0a07f8bad4bcd55
-./vmod-packager.sh -t -d focal -c 454733b82a3279a1603516b4f0a07f8bad4bcd55 -p trunk- test-varnish-modules70 && ls ${VRD}/pkgs/debs/test-varnish-modules70/trunk-test-varnish-modules70_140.0.1~focal-1_amd64.deb
-./vmod-packager.sh -t -d centos8 -c 454733b82a3279a1603516b4f0a07f8bad4bcd55 -p trunk- test-varnish-modules70 && ls ${VRD}/pkgs/rpms/test-varnish-modules70/trunk-test-varnish-modules70-140.0.1-1.el8.x86_64.rpm 
-./vmod-packager.sh -t -d arch -c 454733b82a3279a1603516b4f0a07f8bad4bcd55 -p trunk- test-varnish-modules70 && ls ${VRD}/pkgs/arch/test-varnish-modules70/trunk-test-varnish-modules70-140.0.1-1-x86_64.pkg.tar.zst
+./vmod-packager.sh -t -d focal -c 454733b82a3279a1603516b4f0a07f8bad4bcd55 -p trunk- test-varnish-modules70; ls ${VRD}/pkgs/debs/test-varnish-modules70/trunk-test-varnish-modules70_140.0.1~focal-1_amd64.deb
+./vmod-packager.sh -t -d centos8 -c 454733b82a3279a1603516b4f0a07f8bad4bcd55 -p trunk- test-varnish-modules70; ls ${VRD}/pkgs/rpms/test-varnish-modules70/trunk-test-varnish-modules70-140.0.1-1.el8.x86_64.rpm 
+./vmod-packager.sh -t -d arch -c 454733b82a3279a1603516b4f0a07f8bad4bcd55 -p trunk- test-varnish-modules70; ls ${VRD}/pkgs/arch/test-varnish-modules70/trunk-test-varnish-modules70-140.0.1-1-x86_64.pkg.tar.zst
 
 # libvmod-digest
-./vmod-packager.sh -t -d focal -v 7.0.0 src/test-libvmod-digest70 && ls ${VRD}/pkgs/debs/test-libvmod-digest70/test-libvmod-digest70_140.0.1~focal-1_amd64.deb
-./vmod-packager.sh -t -d centos8 -v 7.0.0 src/test-libvmod-digest70 && ls ${VRD}/pkgs/rpms/test-libvmod-digest70/test-libvmod-digest70-140.0.1-1.el8.x86_64.rpm
-./vmod-packager.sh -t -d arch -v 7.0.0 src/test-libvmod-digest70 && ls ${VRD}/pkgs/arch/test-varnish-modules70/test-libvmod-digest70-140.0.1-1-x86_64.pkg.tar.zst
+./vmod-packager.sh -t -d focal -v 7.0.0 src/test-libvmod-digest70; ls ${VRD}/pkgs/debs/test-libvmod-digest70/test-libvmod-digest70_140.0.1~focal-1_amd64.deb
+./vmod-packager.sh -t -d centos8 -v 7.0.0 src/test-libvmod-digest70; ls ${VRD}/pkgs/rpms/test-libvmod-digest70/test-libvmod-digest70-140.0.1-1.el8.x86_64.rpm
+./vmod-packager.sh -t -d arch -v 7.0.0 src/test-libvmod-digest70; ls ${VRD}/pkgs/arch/test-libvmod-digest70/test-libvmod-digest70-140.0.1-1-x86_64.pkg.tar.zst
 
 # libvdp-pesi
-./vmod-packager.sh -t -d focal -k -v 7.0.0 src/test-libvdp-pesi70 && ls ${VRD}/pkgs/debs/test-libvdp-pesi70/test-libvdp-pesi70_140.0.1~focal-1_amd64.deb && ls ${VRD}/pkgs/debs/varnish/varnish_7.0.0-1vmp~focal_amd64.deb
-./vmod-packager.sh -t -d buster -k -v 7.0.0 src/test-libvdp-pesi70 && ls ${VRD}/pkgs/debs/test-libvdp-pesi70/test-libvdp-pesi70_140.0.1~buster-1_amd64.deb && ls ${VRD}/pkgs/debs/varnish/varnish_7.0.0-1vmp~buster_amd64.deb
-./vmod-packager.sh -t -d centos8 -k -v 7.0.0 src/test-libvdp-pesi70 && ls ${VRD}/pkgs/rpms/test-libvdp-pesi70/test-libvdp-pesi70-140.0.1-1.el8.x86_64.rpm && ls ${VRD}/pkgs/rpms/varnish/varnish-7.0.0-1vmp.el8.x86_64.rpm
+./vmod-packager.sh -t -d focal -k -v 7.0.0 src/test-libvdp-pesi70; ls ${VRD}/pkgs/debs/test-libvdp-pesi70/test-libvdp-pesi70_140.0.1~focal-1_amd64.deb; ls ${VRD}/pkgs/debs/varnish/varnish_7.0.0-1vmp~focal_amd64.deb
+./vmod-packager.sh -t -d buster -k -v 7.0.0 src/test-libvdp-pesi70; ls ${VRD}/pkgs/debs/test-libvdp-pesi70/test-libvdp-pesi70_140.0.1~buster-1_amd64.deb; ls ${VRD}/pkgs/debs/varnish/varnish_7.0.0-1vmp~buster_amd64.deb
+./vmod-packager.sh -t -d centos8 -k -v 7.0.0 src/test-libvdp-pesi70; ls ${VRD}/pkgs/rpms/test-libvdp-pesi70/test-libvdp-pesi70-140.0.1-1.el8.x86_64.rpm; ls ${VRD}/pkgs/rpms/varnish/varnish-7.0.0-1vmp.el8.x86_64.rpm
 
 # varnish-modules
-./vmod-packager.sh -t -d focal -k -r varnish-cache src/test-varnish-modules70 && ls ${VRD}/pkgs/debs/test-libvdp-pesi70/test-libvdp-pesi70_140.0.1~focal-1_amd64.deb && ls ${VRD}/pkgs/debs/varnish/varnish_`date +%Y%m%d`.*-1vmp+fromsrc~focal_amd64.deb
-./vmod-packager.sh -t -d centos8 -k -r varnish-cache src/test-varnish-modules70 && ls ${VRD}/pkgs/rpms/test-libvdp-pesi70/test-libvdp-pesi70-140.0.1-1.el8.x86_64.rpm && ls ${VRD}/pkgs/rpms/varnish/varnish-`date +%Y%m%d`.*-1vmp+fromsrc.el8.x86_64.rpm
-./vmod-packager.sh -t -d arch -k -r varnish-cache src/test-varnish-modules70/ && ls pkgs/arch/varnish/varnish-7.0.0-1-x86_64.pkg.tar.zst
+./vmod-packager.sh -t -d focal -k -r varnish-cache src/test-varnish-modules70; ls ${VRD}/pkgs/debs/test-libvdp-pesi70/test-libvdp-pesi70_140.0.1~focal-1_amd64.deb; ls ${VRD}/pkgs/debs/varnish/varnish_`date +%Y%m%d`.*-1vmp+fromsrc~focal_amd64.deb
+./vmod-packager.sh -t -d centos8 -k -r varnish-cache src/test-varnish-modules70; ls ${VRD}/pkgs/rpms/test-libvdp-pesi70/test-libvdp-pesi70-140.0.1-1.el8.x86_64.rpm; ls ${VRD}/pkgs/rpms/varnish/varnish-`date +%Y%m%d`.*-1vmp+fromsrc.el8.x86_64.rpm
+./vmod-packager.sh -t -d arch -k -r varnish-cache src/test-varnish-modules70/; ls pkgs/arch/varnish/varnish-`date +%Y%m%d`.*-1-x86_64.pkg.tar.zst
 
 echo "pass basic test"

--- a/script/test/test.sh
+++ b/script/test/test.sh
@@ -61,6 +61,7 @@ export VMP_DBG_CACHE=1
 # libvmod-digest
 ./vmod-packager.sh -t -d focal -v 7.0.0 src/test-libvmod-digest70 && ls ${VRD}/pkgs/debs/test-libvmod-digest70/test-libvmod-digest70_140.0.1~focal-1_amd64.deb
 ./vmod-packager.sh -t -d centos8 -v 7.0.0 src/test-libvmod-digest70 && ls ${VRD}/pkgs/rpms/test-libvmod-digest70/test-libvmod-digest70-140.0.1-1.el8.x86_64.rpm
+./vmod-packager.sh -t -d arch -v 7.0.0 src/test-libvmod-digest70 && ls ${VRD}/pkgs/arch/test-varnish-modules70/test-libvmod-digest70-140.0.1-1-x86_64.pkg.tar.zst
 
 # libvdp-pesi
 ./vmod-packager.sh -t -d focal -k -v 7.0.0 src/test-libvdp-pesi70 && ls ${VRD}/pkgs/debs/test-libvdp-pesi70/test-libvdp-pesi70_140.0.1~focal-1_amd64.deb && ls ${VRD}/pkgs/debs/varnish/varnish_7.0.0-1vmp~focal_amd64.deb
@@ -70,5 +71,6 @@ export VMP_DBG_CACHE=1
 # varnish-modules
 ./vmod-packager.sh -t -d focal -k -r varnish-cache src/test-varnish-modules70 && ls ${VRD}/pkgs/debs/test-libvdp-pesi70/test-libvdp-pesi70_140.0.1~focal-1_amd64.deb && ls ${VRD}/pkgs/debs/varnish/varnish_`date +%Y%m%d`.*-1vmp+fromsrc~focal_amd64.deb
 ./vmod-packager.sh -t -d centos8 -k -r varnish-cache src/test-varnish-modules70 && ls ${VRD}/pkgs/rpms/test-libvdp-pesi70/test-libvdp-pesi70-140.0.1-1.el8.x86_64.rpm && ls ${VRD}/pkgs/rpms/varnish/varnish-`date +%Y%m%d`.*-1vmp+fromsrc.el8.x86_64.rpm
+./vmod-packager.sh -t -d arch -k -r varnish-cache src/test-varnish-modules70/ && ls pkgs/arch/varnish/varnish-7.0.0-1-x86_64.pkg.tar.zst
 
 echo "pass basic test"

--- a/script/tool/varnish-build.sh
+++ b/script/tool/varnish-build.sh
@@ -7,7 +7,7 @@ if [ ! -d "${VMP_VARNISH_ORG_DIR}/pkg-varnish-cache" ]; then
 fi
 
 # https://github.com/varnishcache/varnish-cache/wiki/Release-procedure
-# `make dist`` required to build doc
+# `make dist` required to build doc
 cd ${VMP_ROOT_DIR}/src
 if [ ! -d "${VMP_ROOT_DIR}/src/doc/html" ]; then
     mkdir -p ${VMP_ROOT_DIR}/src/doc/html
@@ -22,8 +22,10 @@ if which dpkg &>/dev/null; then
     export VMP_PKGTYPE=deb
 elif which rpm &> /dev/null; then
     export VMP_PKGTYPE=rpm
+elif which pacman &> /dev/null; then
+    export VMP_PKGTYPE=arch
 else
-    echo "Error: varnish builds aren't supported for other packages than deb and rpm"
+    echo "Error: varnish builds aren't supported for other packages than deb, rpm and arch"
     exit 1
 fi
 

--- a/vmod-packager.sh
+++ b/vmod-packager.sh
@@ -158,6 +158,7 @@ if [[ -n "${VMP_VARNISH_SRC}" ]]; then
     echo "./varnish/${VMP_VARNISH_SRC} is not found" 1>&2
     usage_exit
   fi
+  VMP_HASH=src
 
 elif [[ -n "${VMP_HASH}" ]]; then
   VMP_VARNISH_VER=trunk


### PR DESCRIPTION
this started as a PR to build `varnish` packages for `arch`, but I had to fix a few things along the way. Notably, `digest` and `pesi` don't compile/test cleanly and need local patches until the fixes are upstreamed. Also, I figured out why tests didn't fail previously: `set -e` was thwarted by `&&` (see https://mywiki.wooledge.org/BashFAQ/105 for some fun)